### PR TITLE
Bump github-action-markdown-cli

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,5 +15,5 @@ jobs:
     - name: markdownlint-cli
       uses: nosborn/github-action-markdown-cli@v1.1.1
       with:
-        config_file: "markdownlint.json"
+        config_file: ".github/workflows/markdownlint.json"
         files: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@master
     - name: markdownlint-cli
-      uses: nosborn/github-action-markdown-cli@v1.1
+      uses: nosborn/github-action-markdown-cli@v1.1.1
       with:
         config_file: "markdownlint.json"
         files: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  build:
+  markdown-lint:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Use the latest version (https://github.com/marketplace/actions/markdownlint-cli).